### PR TITLE
changing the package.json to use the updated hook_url structure for node...

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dotenv": "^0.4.0",
     "express": "^4.4.4",
     "logfmt": "^1.1.2",
-    "node-slack": "git+https://github.com/xoxco/node-slack.git"
+    "node-slack": "git+https://github.com/Dahlgren/node-slack.git#hook-url"
   },
   "engines": {
     "node": "0.10.x"


### PR DESCRIPTION
The current node-slack library in package.json is old. Slack changed to a new hooks.slack.com url structure for the webhooks.  The package added uses an updated version of the node-slack library. The only difference is the domain is no longer the company name, but the hooks.slack.com url.