### PR TITLE
Slack API updates, Heroku Deploy, and HEX Colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ docker run -e PORT=5000 -e SLACK_TOKEN=123123 \
   -p 5000:5000 -d bitbucket-slack-pr-hook
 ```
 
+You can also adjust the HEX Colors for notification attachments by adjusting any environment variables in the example below.
+
+```
+#Adjust HEX colors ie: #fff000
+
+#Updated, Created
+HEX_INFO = #3498db
+
+#Declined
+HEX_DANGER = #e74c3c
+
+#Unapprove, Comment: Created, Comment: Deleted, Comment: Updated
+HEX_WARNING = #f1c40f
+
+#Merge & Approve
+HEX_SUCCESS = #2ecc71
+
+```
+
 ## Installation
 
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)    

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ So all we can do is something like "Comment posted for *a* PR" and then the snip
 ## Requirements
 
   * [Bitbucket](https://bitbucket.org/) repository with admin rights
-  * [Slack](https://slack.com/) channel token: Get your Slack token from your "integrations" page
+  * [Slack](https://slack.com/) Incoming Webhook Url: Get your Slack token from your "integrations" page
   * [Node.js](http://nodejs.org/) **OR** [Docker](https://www.docker.com/)
 
 ## Configuration
@@ -41,13 +41,14 @@ If you want to use `.env` file, copy the `example.env` as `.env` and modify it a
 
 ```
 PORT=5000
-SLACK_TOKEN=getfromslack
-SLACK_DOMAIN=mycompany
-SLACK_CHANNEL=mychannel
-SLACK_USERNAME=MyAwesomeBot
+SLACK_WEBHOOKURL=https://hooks.slack.com/services/.../.../...
+SLACK_USERNAME = AwesomeBot
+SLACK_CHANNEL = Repository
 ```
 
-Important: if you're going to use a `.env` file AND using Docker, edit it before building the Dockerfile.
+Note: Setting the `SLACK_USERNAME` or `SLACK_CHANNEL` will override the settings set on the incoming webhook integration page. If you want your team to edit any of these settings without redeploying, do not add them to your `.env` file.
+
+**Important**: if you're going to use a `.env` file AND using Docker, edit it before building the Dockerfile.
 
 When running the service in Docker container, the config values can be provided as parameters:
 
@@ -60,7 +61,11 @@ docker run -e PORT=5000 -e SLACK_TOKEN=123123 \
 
 ## Installation
 
-You can install it in your own local infrastructure or in a cloud service like heroku.
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)    
+    
+**OR**    
+    
+You can install it in your own local infrastructure or in any other cloud service.
 Alternatively, you can build a Docker image and [deploy as container](#installation-using-docker)
 
   1. Set up a server address in your local infrastructure that will serve this application (eg: `slackapi.mycompany.com` or `slackapi.heroku.com`)
@@ -86,8 +91,7 @@ which makes it easy to setup the environment without worrying about the requirem
 
   5. Start container with appropriate `-e` config parameters:
 
-        docker run -e PORT=5000 -e SLACK_TOKEN=123123 \
-          -e SLACK_DOMAIN=company -e SLACK_CHANNEL=channel \
+        docker run -e PORT=5000 -e SLACK_WEBHOOK=webhookurl \
           -p 5000:5000 -d bitbucket-slack-pr-hook
 
   6. Ensure the container is running (you should also be able to access the service using web browser: `http://<dockerhost>:5000/`).

--- a/app.json
+++ b/app.json
@@ -1,0 +1,25 @@
+{
+  "name": "bitbucket-slack-pr-hook",
+  "description": "Receive Pull Requests notifications from Bitbucket and send them to Slack.",
+  "keywords": [
+    "productivity",
+    "slack",
+    "bitbucket",
+    "pull requests"
+  ],
+  "repository": "https://github.com/lfilho/bitbucket-slack-pr-hook",
+  "env": {
+    "SLACK_WEBHOOK": {
+      "description": "The slack incoming webhook url.",
+      "required": true
+    },
+    "SLACK_USERNAME": {
+      "description": "The slack bot's username. NOTE: Setting this will override integration settings.",
+      "required": false
+    },
+    "SLACK_CHANNEL": {
+      "description": "The slack channel to send notifications to. NOTE: Setting this will override integration settings.",
+      "required": false
+    }
+  }
+}

--- a/app.json
+++ b/app.json
@@ -20,6 +20,26 @@
     "SLACK_CHANNEL": {
       "description": "The slack channel to send notifications to. NOTE: Setting this will override integration settings.",
       "required": false
+    },
+    "HEX_INFO": {
+      "description": "Hex Color for Merge & Approve",
+      "value": "#3498db",
+      "required": false
+    },
+    "HEX_DANGER": {
+      "description": "Hex Color for Declined",
+      "value": "#e74c3c",
+      "required": false
+    },
+    "HEX_WARNING": {
+      "description": "Hex Color for Unapprove, Comment: Created, Comment: Deleted, Comment: Updated",
+      "value": "#f1c40f",
+      "required": false
+    },
+    "HEX_SUCCESS": {
+      "description": "Hex Color for Merge & Approve",
+      "value": "#2ecc71",
+      "required": false
     }
   }
 }

--- a/example.env
+++ b/example.env
@@ -1,5 +1,5 @@
 PORT=5000
-SLACK_TOKEN=getslack
-SLACK_DOMAIN=mycompany
-SLACK_CHANNEL=mychannel
-SLACK_USERNAME=MyAwesomeBot
+SLACK_WEBHOOK=https://hooks.slack.com/services/.../.../...
+#These values are optional, but it will override any settings in the integrations page. Thus, if you want your to be able to edit the username and channel delete the two config settings below.
+SLACK_USERNAME = AwesomeBot
+SLACK_CHANNEL = Repository

--- a/example.env
+++ b/example.env
@@ -1,5 +1,20 @@
 PORT=5000
 SLACK_WEBHOOK=https://hooks.slack.com/services/.../.../...
-#These values are optional, but it will override any settings in the integrations page. Thus, if you want your to be able to edit the username and channel delete the two config settings below.
+
+#These values are optional, but it will override any settings in the integrations page.
 SLACK_USERNAME = AwesomeBot
 SLACK_CHANNEL = Repository
+
+#Adjust HEX colors ie: #fff000
+
+#Updated, Created
+HEX_INFO = #3498db
+
+#Declined
+HEX_DANGER = #e74c3c
+
+#Unapprove, Comment: Created, Comment: Deleted, Comment: Updated
+HEX_WARNING = #f1c40f
+
+#Merge & Approve
+HEX_SUCCESS = #2ecc71

--- a/lib/bitbucketParser.js
+++ b/lib/bitbucketParser.js
@@ -176,7 +176,7 @@ module.exports = (function () {
      * to the notification service. See [0] for the messages Bitbucket
      * may send.
      *
-     * 0: https://confluence.atlassian.com/display/BITBUCKET/Pull+Request+POST+hook+management
+     * 0: https://confluence.atlassian.com/bitbucket/pull-request-post-service-management-385913080.html
      **/
     var generateMessage = function (message) {
         var supportedActions = [

--- a/lib/config.js
+++ b/lib/config.js
@@ -6,5 +6,9 @@ module.exports = {
     port: Number(process.env.PORT) || 5000,
     webhook: process.env.SLACK_WEBHOOK, // Slack Incoming Webhook
     channel: '#' + process.env.SLACK_CHANNEL, // Slack channel without # prefix
-    username: process.env.SLACK_USERNAME
+    username: process.env.SLACK_USERNAME,
+    danger: process.env.HEX_DANGER,
+    info: process.env.HEX_INFO,
+    success: process.env.HEX_SUCCESS,
+    warning: process.env.HEX_WARNING
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,8 +4,7 @@ require('dotenv').load();
 
 module.exports = {
     port: Number(process.env.PORT) || 5000,
-    token: process.env.SLACK_TOKEN, // Slack channel token
-    domain: process.env.SLACK_DOMAIN, // Slack domain as in "mycompany.slack.com"
+    webhook: process.env.SLACK_WEBHOOK, // Slack Incoming Webhook
     channel: '#' + process.env.SLACK_CHANNEL, // Slack channel without # prefix
-    username: process.env.SLACK_USERNAME || 'MyAwesomeBot'
+    username: process.env.SLACK_USERNAME
 };

--- a/lib/slackService.js
+++ b/lib/slackService.js
@@ -6,15 +6,20 @@ var config = require('./config');
 function noop() {}
 
 module.exports = (function () {
-    var slack = new Slack(config.domain, config.token),
-
-     params = {
-        channel: config.channel,
-        username: config.username,
+    var slack = new Slack(config.webhook);
+    var params = {
         attachments: []
-    },
+    };
 
-     sendMessage = function (message, channel) {
+    if (typeof config.username !== 'undefined') {
+        params.username = config.username;
+    }
+
+    if (config.channel !== '#undefined') {
+        params.channel = config.channel;
+    }
+
+    var sendMessage = function (message, channel) {
         // `text` is mandatory:
         params.text = message.fallback;
         params.attachments[0] = message;

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,4 +1,5 @@
 'use strict';
+var config = require('./config');
 
 module.exports = {
     truncate: function (string) {
@@ -22,10 +23,10 @@ module.exports = {
     },
 
     COLORS: {
-        red: '#ff0000',
-        green: '#00ff00',
-        blue: '#0000ff',
-        yellow: '#ffff00'
+        red: config.danger || '#e74c3c',
+        green: config.success || '#2ecc71',
+        blue: config.info || '#3498db',
+        yellow: config.warning ||'#f1c40f'
     }
 };
 


### PR DESCRIPTION
This PR includes

- Update to use incoming webhook for Slack API
- Adjustable HEX colors
- Flat HEX colors for defaults
- Deploy to Heroku Implementation to ease the process
- Update example URL reference in bitbucketParser.js
- Update to README to reflect new changes

Features have been tested and working :+1:.
(Docker readme may need to be tweaked, as I'm not entirely familiar with Docker set up)